### PR TITLE
Ajay admin work

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -24,6 +24,7 @@ auth.post('/login', parsers.json, async ctx => {
             ctx.status = 200;
             response.result = 'success';
             response.username = user.username;
+            response.is_admin = user.is_admin
             ctx.body = JSON.stringify(response);
         } else {
             ctx.status = 400;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -25,6 +25,7 @@ auth.post('/login', parsers.json, async ctx => {
             response.result = 'success';
             response.username = user.username;
             response.is_admin = user.is_admin
+            response.id = user.id
             ctx.body = JSON.stringify(response);
         } else {
             ctx.status = 400;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -22,15 +22,18 @@ auth.post('/login', parsers.json, async ctx => {
         if (user) {
             ctx.login(user);
             ctx.status = 200;
-            response.result = 'success';
-            response.username = user.username;
-            response.is_admin = user.is_admin
-            response.id = user.id
+            let data = {
+            username: user.username,
+            is_admin: user.is_admin,
+            id: user.id
+            }
+            response.status = 'success';
+            response.data = data;
             ctx.body = JSON.stringify(response);
         } else {
             ctx.status = 400;
-            response.result = 'error';
-            response.error = 'Generic error at login';
+            response.status = 'error';
+            response.errorText = 'Generic error at login';
             ctx.body = JSON.stringify(response);
         }
     })(ctx);

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -63,13 +63,15 @@ users.patch('/:id', parsers.json, async (ctx) => {
         .patch(patchedPayload)
         .findById(ctx.params.id)
 
-        response.result = 'User object successfuly modified';
+        response.status = 'User object successfully modified'
         ctx.body = JSON.stringify(response);
     }
     catch (err){
-        response.result = 'Could not modify user object';
-        response.error = err
+        response.status = 'error'
+        response.errorText = 'Could not modify user object';
+        response.originalError = err
         ctx.status = 400;
+        ctx.status = 200;
         ctx.body = JSON.stringify(response);
     }
 });

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -74,25 +74,25 @@ users.patch('/:id', parsers.json, async (ctx) => {
     }
 });
 
-// users.get('/verifiedusers', parsers.json, async ctx => {
-//     ctx.body = "received request!!!"
-//     // let response = {};
-//     // try {
-//     //     let verifiedIds = await Users.query()
-//     //         .where('isVerified', true)
-//     //         .returning('id')
-//     //     response.result = 'success';
-//     //     response.verifiedIds = verifiedIds
-//     //     ctx.body = JSON.stringify(response);
-//     // }
-//     // catch(err){
-//     //     console.error(err);
-//     //     response.result = 'error';
-//     //     response.error = 'Could not fetch verified IDs';
-//     //     ctx.status = 400;
-//     //     ctx.body = JSON.stringify(response);
-//     // }
-// });
+users.get('/verifiedusers/', parsers.json, async ctx => {
+    ctx.body = "received request!!!"
+    // let response = {};
+    // try {
+    //     let verifiedIds = await Users.query()
+    //         .where('isVerified', true)
+    //         .returning('id')
+    //     response.result = 'success';
+    //     response.verifiedIds = verifiedIds
+    //     ctx.body = JSON.stringify(response);
+    // }
+    // catch(err){
+    //     console.error(err);
+    //     response.result = 'error';
+    //     response.error = 'Could not fetch verified IDs';
+    //     ctx.status = 400;
+    //     ctx.body = JSON.stringify(response);
+    // }
+});
 
 function createUser (userParams) {
     let newUser = userParams;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -50,11 +50,27 @@ users.get('/:id', async ctx => {
 });
 
 users.patch('/:id', parsers.json, async (ctx) => {
-    try{ctx.body = await Users.query()
-        .patch({isVerified: true})
-        .findById(ctx.params.id)}
+    let response = {}
+    try{
+        let targetUser = await Users.query()
+        .findById(ctx.params.id)
+
+        //currently, we have to have dateRegistered and lastLogin in patch request or it won't work
+        let patchedPayload = Object.assign(ctx.request.body, {dateRegistered: targetUser.dateRegistered, lastLogin: 0})
+
+        //actual patch request
+        await Users.query()
+        .patch(patchedPayload)
+        .findById(ctx.params.id)
+
+        response.result = 'success';
+        ctx.body = JSON.stringify(response);
+    }
     catch (err){
-        ctx.body = err
+        response.result = 'error';
+        response.error = err
+        ctx.status = 400;
+        ctx.body = JSON.stringify(response);
     }
 });
 

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -63,11 +63,11 @@ users.patch('/:id', parsers.json, async (ctx) => {
         .patch(patchedPayload)
         .findById(ctx.params.id)
 
-        response.result = 'success';
+        response.result = 'User object successfuly modified';
         ctx.body = JSON.stringify(response);
     }
     catch (err){
-        response.result = 'error';
+        response.result = 'Could not modify user object';
         response.error = err
         ctx.status = 400;
         ctx.body = JSON.stringify(response);

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -74,26 +74,6 @@ users.patch('/:id', parsers.json, async (ctx) => {
     }
 });
 
-users.get('/verifiedusers/', parsers.json, async ctx => {
-    ctx.body = "received request!!!"
-    // let response = {};
-    // try {
-    //     let verifiedIds = await Users.query()
-    //         .where('isVerified', true)
-    //         .returning('id')
-    //     response.result = 'success';
-    //     response.verifiedIds = verifiedIds
-    //     ctx.body = JSON.stringify(response);
-    // }
-    // catch(err){
-    //     console.error(err);
-    //     response.result = 'error';
-    //     response.error = 'Could not fetch verified IDs';
-    //     ctx.status = 400;
-    //     ctx.body = JSON.stringify(response);
-    // }
-});
-
 function createUser (userParams) {
     let newUser = userParams;
     let saltRounds = 10;

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -74,6 +74,26 @@ users.patch('/:id', parsers.json, async (ctx) => {
     }
 });
 
+// users.get('/verifiedusers', parsers.json, async ctx => {
+//     ctx.body = "received request!!!"
+//     // let response = {};
+//     // try {
+//     //     let verifiedIds = await Users.query()
+//     //         .where('isVerified', true)
+//     //         .returning('id')
+//     //     response.result = 'success';
+//     //     response.verifiedIds = verifiedIds
+//     //     ctx.body = JSON.stringify(response);
+//     // }
+//     // catch(err){
+//     //     console.error(err);
+//     //     response.result = 'error';
+//     //     response.error = 'Could not fetch verified IDs';
+//     //     ctx.status = 400;
+//     //     ctx.body = JSON.stringify(response);
+//     // }
+// });
+
 function createUser (userParams) {
     let newUser = userParams;
     let saltRounds = 10;

--- a/backend/routes/verifiedusers.js
+++ b/backend/routes/verifiedusers.js
@@ -14,7 +14,22 @@ const parsers = {
 const verifiedUsers = new Router();
 
 verifiedUsers.get('/', async ctx => {
-  ctx.body = "you hit the endpoint!"
+   let response = {};
+    try {
+        let verifiedUsers = await Users.query()
+            .where('is_verified', true)
+            .returning('id')
+        response.result = 'success';
+        response.verifiedIds = verifiedIds.id
+        ctx.body = JSON.stringify(response);
+    }
+    catch(err){
+        console.error(err);
+        response.result = 'error';
+        response.error = 'Could not fetch verified IDs';
+        ctx.status = 400;
+        ctx.body = JSON.stringify(response);
+    }
 });
 
 module.exports = verifiedUsers;

--- a/backend/routes/verifiedusers.js
+++ b/backend/routes/verifiedusers.js
@@ -17,10 +17,10 @@ verifiedUsers.get('/', async ctx => {
    let response = {};
     try {
         let verifiedUsers = await Users.query()
+            .select('id')
             .where('is_verified', true)
-            .returning('id')
         response.result = 'success';
-        response.verifiedIds = verifiedIds.id
+        response.verifiedIds = idHash(verifiedUsers)
         ctx.body = JSON.stringify(response);
     }
     catch(err){
@@ -31,5 +31,15 @@ verifiedUsers.get('/', async ctx => {
         ctx.body = JSON.stringify(response);
     }
 });
+
+function idHash(users){
+    let result = {}
+
+    for(let i=0; i < users.length; i++){
+        result[users[i].id] = true
+    }
+
+    return result;
+}
 
 module.exports = verifiedUsers;

--- a/backend/routes/verifiedusers.js
+++ b/backend/routes/verifiedusers.js
@@ -19,14 +19,19 @@ verifiedUsers.get('/', async ctx => {
         let verifiedUsers = await Users.query()
             .select('id')
             .where('is_verified', true)
-        response.result = 'success';
-        response.verifiedIds = idHash(verifiedUsers)
+
+        let data = {
+            verifiedIds: idHash(verifiedUsers)
+        }
+        response.status = 'success';
+        response.data = data
         ctx.body = JSON.stringify(response);
     }
     catch(err){
         console.error(err);
-        response.result = 'error';
-        response.error = 'Could not fetch verified IDs';
+        response.status = "error";
+        response.errorText = 'Could not fetch verified IDs';
+        response.originalError = err;
         ctx.status = 400;
         ctx.body = JSON.stringify(response);
     }

--- a/backend/routes/verifiedusers.js
+++ b/backend/routes/verifiedusers.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Router = require('koa-router');
+const parser = require('koa-body');
+
+const Users = require('../models/users');
+
+const parsers = {
+    query: parser({urlencoded: true, multipart: false, json: false}),
+    form: parser({urlencoded: false, multipart: true, json: false}),
+    json: parser({urlencoded: false, multipart: false, json: true}),
+};
+
+const verifiedUsers = new Router();
+
+verifiedUsers.get('/', async ctx => {
+  ctx.body = "you hit the endpoint!"
+});
+
+module.exports = verifiedUsers;

--- a/frontend/src/components/HeatMap.js
+++ b/frontend/src/components/HeatMap.js
@@ -52,14 +52,14 @@ class HeatMap extends Component {
   componentDidUpdate(){
     //Clear the map. TODO: find a more elegant way
     for(let i in this.map._layers) {
-        // console.log(this.map._layers[i]);
-        // console.log(i);
+        console.log(this.map._layers[i]);
+        console.log(i);
         if(this.map._layers[i]._path != undefined ||
            this.map._layers[i]._latlng != undefined) {
           this.map.removeLayer(this.map._layers[i]);
         } else {
-            // console.log(this.map._layers[i]);
-            // console.log(i);
+            console.log(this.map._layers[i]);
+            console.log(i);
         }
     }
 

--- a/frontend/src/components/HeatMap.js
+++ b/frontend/src/components/HeatMap.js
@@ -52,14 +52,14 @@ class HeatMap extends Component {
   componentDidUpdate(){
     //Clear the map. TODO: find a more elegant way
     for(let i in this.map._layers) {
-        console.log(this.map._layers[i]);
-        console.log(i);
+        // console.log(this.map._layers[i]);
+        // console.log(i);
         if(this.map._layers[i]._path != undefined ||
            this.map._layers[i]._latlng != undefined) {
           this.map.removeLayer(this.map._layers[i]);
         } else {
-            console.log(this.map._layers[i]);
-            console.log(i);
+            // console.log(this.map._layers[i]);
+            // console.log(i);
         }
     }
 

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -35,7 +35,6 @@ class Login extends Component {
             .then((response) => {
                 if (response.status === 200) {
                     session.update({ loggedInUser: response.data });
-                    debugger
                     window.location.hash = "#report";
                 }
             })

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -35,6 +35,7 @@ class Login extends Component {
             .then((response) => {
                 if (response.status === 200) {
                     session.update({ loggedInUser: response.data });
+                    debugger
                     window.location.hash = "#report";
                 }
             })

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -24,7 +24,9 @@ class Login extends Component {
         this.login = this.login.bind(this);
     }
 
-    login() {
+    login(e) {
+        e.preventDefault();
+        
         let session = this.context;
         let postData = {
             username: this.state.username,

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -33,8 +33,9 @@ class Login extends Component {
 
         Api.post("auth/login", postData)
             .then((response) => {
+                debugger
                 if (response.status === 200) {
-                    session.update({ loggedInUser: response.data });
+                    session.update({ loggedInUser: response.data.data });
                     window.location.hash = "#report";
                 }
             })

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -33,7 +33,6 @@ class Login extends Component {
 
         Api.post("auth/login", postData)
             .then((response) => {
-                debugger
                 if (response.status === 200) {
                     session.update({ loggedInUser: response.data.data });
                     window.location.hash = "#report";

--- a/frontend/src/components/Menu.js
+++ b/frontend/src/components/Menu.js
@@ -21,7 +21,7 @@ class Menu extends Component {
         {id: "logout", text: "Sign out"}
       ];
 
-      if (session.data.loggedInUser.admin_p) {
+      if (session.data.loggedInUser.is_admin) {
         menuItems.push (
           {id: "admin", text: "Admin"}
         )

--- a/frontend/src/components/RegistrationPage.js
+++ b/frontend/src/components/RegistrationPage.js
@@ -50,7 +50,7 @@ class RegistrationPage extends Component {
                             .then((logInResponse) => {
                                 if (logInResponse.status === 200) {
                                     session.update({
-                                        loggedInUser: logInResponse.data,
+                                        loggedInUser: logInResponse.data.data,
                                         newlyRegistered: true,
                                     });
                                     window.location.hash = "#report";

--- a/frontend/src/components/RegistrationPage.js
+++ b/frontend/src/components/RegistrationPage.js
@@ -23,7 +23,9 @@ class RegistrationPage extends Component {
         this.registerUser = this.registerUser.bind(this);
     }
 
-    registerUser() {
+    registerUser(e) {
+        e.preventDefault(); 
+        
         let session = this.context;
 
         let postData = {

--- a/frontend/src/containers/Admin.js
+++ b/frontend/src/containers/Admin.js
@@ -21,7 +21,7 @@ class Admin extends Component {
 
   componentWillUpdate(){
     let session = this.context;
-      if (!session.data.loggedInUser || session.data.loggedInUser.admin_p !== true){
+      if (!session.data.loggedInUser || session.data.loggedInUser.is_admin !== true){
         window.location.hash = "#report"
       }
   }
@@ -35,7 +35,7 @@ class Admin extends Component {
   toggleUser(toggledUser) {
     let session = this.context;
 
-    if (session.data.loggedInUser.admin_p === true){
+    if (session.data.loggedInUser.is_admin === true){
 
       Api.patch(`users/${toggledUser.id}`,
         {

--- a/frontend/src/containers/Admin.js
+++ b/frontend/src/containers/Admin.js
@@ -63,7 +63,7 @@ class Admin extends Component {
       let userNameToShow = (user.firstName || user.lastName)
           ? user.firstName + ' ' + user.lastName
           : user.username;
-      let userActiveClass = user.isVerified ? ' verified' : ' inactive';
+      let userActiveClass = user.isVerified ? ' verified' : ' unverified';
       itemsToRender.push(
         <p className='admin-row'
             key={user.id}>

--- a/frontend/src/containers/Admin.js
+++ b/frontend/src/containers/Admin.js
@@ -59,18 +59,18 @@ class Admin extends Component {
     let itemsToRender = [];
     for (let i = 0; i < users.length; i++) {
       let user = users[i];
-      let buttonText = user.isVerified ? "Deactivate" : "Activate";
+      let buttonText = user.isVerified ? "Unverify" : "Verify";
       let userNameToShow = (user.firstName || user.lastName)
           ? user.firstName + ' ' + user.lastName
           : user.username;
-      let userActiveClass = user.isVerified ? ' active' : ' inactive';
+      let userActiveClass = user.isVerified ? ' verified' : ' inactive';
       itemsToRender.push(
         <p className='admin-row'
             key={user.id}>
           <span className={'user-name-in-overview' + userActiveClass}>{userNameToShow}</span>
-          <button className='admin-button delete-button' onClick={() => this.deleteUser(user)}>
+          {/* <button className='admin-button delete-button' onClick={() => this.deleteUser(user)}>
             Dismiss
-          </button>
+          </button> */}
           <button className='admin-button' onClick={() => this.toggleUser(user)}>
             {buttonText}
           </button>

--- a/frontend/src/containers/ViewData.js
+++ b/frontend/src/containers/ViewData.js
@@ -52,18 +52,21 @@ class Data extends Component {
     let verifiedUsers;
     Api.get('verifiedusers').then(response => {
       verifiedUsers = response.data.verifiedIds
-
+      let session = this.context;
+      //adds current user to reports we want to show
+      if (session.data.loggedInUser){
+        verifiedUsers[session.data.loggedInUser.id] = true
+      }
+      
       //fetches reports
       let reportData;
       Api.get('reports').then(response => {
         reportData = response.data
 
         //sets state data to filtered out reports
-        let session = this.context;
-        debugger
         this.setState({
-          data: reportData.filter(report => verifiedUsers.includes(report.reporterId) || report.reporterId === session.data.loggedInUser.id),
-          originalData: reportData.filter(report => verifiedUsers.includes(report.reporterId) || report.reporterId === session.data.loggedInUser.id)
+          data: reportData.filter(report => verifiedUsers[report.reporterId]),
+          originalData: reportData.filter(report => verifiedUsers[report.reporterId])
         })
       });
     })

--- a/frontend/src/containers/ViewData.js
+++ b/frontend/src/containers/ViewData.js
@@ -10,6 +10,7 @@ import HeatMap from './../components/HeatMap';
 import HeatMapSettings from './../components/HeatMapSettings';
 
 import { truckTypes } from '../components/TruckSelection';
+import { SessionContext } from "../utils/Session.js";
 
 class Data extends Component {
   constructor(props) {
@@ -27,6 +28,7 @@ class Data extends Component {
     this.state = {
       originalData: [],
       data: [],
+      verifiedUsers: [],
       truckTypesToShow: truckTypesToShow,
       fromTime: new Date(new Date().setFullYear(new Date().getFullYear() - 1)), // wows
       toTime: new Date()
@@ -46,14 +48,25 @@ class Data extends Component {
   }
 
   fetchData () {
+    //fetches verified user ids
+    let verifiedUsers;
     Api.get('verifiedusers').then(response => {
-      console.log(response)
-    })
+      verifiedUsers = response.data.verifiedIds
 
-    Api.get('reports').then(response => {
-      this.setState({data: response.data,
-                     originalData: response.data});
-    });
+      //fetches reports
+      let reportData;
+      Api.get('reports').then(response => {
+        reportData = response.data
+
+        //sets state data to filtered out reports
+        let session = this.context;
+        debugger
+        this.setState({
+          data: reportData.filter(report => verifiedUsers.includes(report.reporterId) || report.reporterId === session.data.loggedInUser.id),
+          originalData: reportData.filter(report => verifiedUsers.includes(report.reporterId) || report.reporterId === session.data.loggedInUser.id)
+        })
+      });
+    })
   }
 
   updateTruck (truckKey, shouldWeShow) {
@@ -115,5 +128,7 @@ class Data extends Component {
     );
   }
 }
+
+Data.contextType = SessionContext;
 
 export default Data;

--- a/frontend/src/containers/ViewData.js
+++ b/frontend/src/containers/ViewData.js
@@ -48,25 +48,26 @@ class Data extends Component {
   }
 
   fetchData () {
-    //fetches verified user ids
-    let verifiedUsers;
+    //Fetches verified user ids
+    let validUsers;
     Api.get('verifiedusers').then(response => {
-      verifiedUsers = response.data.verifiedIds
+      validUsers = response.data.verifiedIds
+
+      //Adds current user to reports we want to show
       let session = this.context;
-      //adds current user to reports we want to show
       if (session.data.loggedInUser){
-        verifiedUsers[session.data.loggedInUser.id] = true
+        validUsers[session.data.loggedInUser.id] = true
       }
-      
-      //fetches reports
+
+      //Fetches reports
       let reportData;
       Api.get('reports').then(response => {
         reportData = response.data
 
-        //sets state data to filtered out reports
+        //Sets state data to filtered out reports
         this.setState({
-          data: reportData.filter(report => verifiedUsers[report.reporterId]),
-          originalData: reportData.filter(report => verifiedUsers[report.reporterId])
+          data: reportData.filter(report => validUsers[report.reporterId]),
+          originalData: reportData.filter(report => validUsers[report.reporterId])
         })
       });
     })

--- a/frontend/src/containers/ViewData.js
+++ b/frontend/src/containers/ViewData.js
@@ -51,7 +51,7 @@ class Data extends Component {
     //Fetches verified user ids
     let validUsers;
     Api.get('verifiedusers').then(response => {
-      validUsers = response.data.verifiedIds
+      validUsers = response.data.data.verifiedIds
 
       //Adds current user to reports we want to show
       let session = this.context;

--- a/frontend/src/containers/ViewData.js
+++ b/frontend/src/containers/ViewData.js
@@ -46,6 +46,10 @@ class Data extends Component {
   }
 
   fetchData () {
+    // Api.get('users/verifiedusers').then(response => {
+    //   console.log(response)
+    // })
+
     Api.get('reports').then(response => {
       this.setState({data: response.data,
                      originalData: response.data});

--- a/frontend/src/containers/ViewData.js
+++ b/frontend/src/containers/ViewData.js
@@ -46,9 +46,9 @@ class Data extends Component {
   }
 
   fetchData () {
-    // Api.get('users/verifiedusers').then(response => {
-    //   console.log(response)
-    // })
+    Api.get('verifiedusers').then(response => {
+      console.log(response)
+    })
 
     Api.get('reports').then(response => {
       this.setState({data: response.data,

--- a/frontend/src/styles/admin.scss
+++ b/frontend/src/styles/admin.scss
@@ -35,7 +35,7 @@
         }
     }
 
-    .inactive {
+    .unverified {
         color: $dark-grey;
     }
 

--- a/frontend/src/utils/Api.js
+++ b/frontend/src/utils/Api.js
@@ -26,8 +26,8 @@ let Api = {
         });
   },
 
-  patch: function (endPoint, postObject) {
-    return axios.patch(urlRoot + endPoint, postObject, { withCredentials: true })
+  patch: function (endPoint, patchObject) {
+    return axios.patch(urlRoot + endPoint, patchObject, { withCredentials: true })
       .then(response => {
         // We keep this here, generic API stuff can go here
         return response;


### PR DESCRIPTION
This pull request

- Creates an Admin functionality where admin users can change the `is_verified` flag of all users
- Limits the shown reports to only those from verified users + the current user logged in (if one). 

Notes: 

- I tried to keep consistent with how things were formatted, keeping the two new backend routes in line with how the previous routes were implemented. 
- Had to pass the logged-in user's `is_admin` and `id` to the frontend to have the admin and reports pages working properly. 
- Right now - the patch request only works if I include `dateRegistered` and `lastLogin` in the payload - which is strange and inefficient. I'm not sure why that is the case.